### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Build and Publish Android Build Image
-      uses: elgohr/Publish-Docker-Github-Action@2.7
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: vgaidarji/docker-android-build
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -14,7 +14,7 @@ jobs:
         workdir: docker-android-build
         tag_names: true
     - name: Build and Publish Android Emulator Image
-      uses: elgohr/Publish-Docker-Github-Action@2.7
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: vgaidarji/docker-android-emulator
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore